### PR TITLE
Make phonenumber, address, and role optional in user schema

### DIFF
--- a/Validation/User/registerValidator.js
+++ b/Validation/User/registerValidator.js
@@ -23,17 +23,14 @@ const RegisterSchema = Joi.object({
     }),
 
   role: Joi.string()
-    .required()
-    .valid("student", "school", "volunteer", "admin", "partner")
+    .valid("student", "school", "volunteer", "admin", "partner", "")
     .messages({
       "any.required": "Role required",
       "any.only":
         "Role must be one of 'student', 'school', 'volunteer', 'admin', 'partner'",
     }),
 
-  phoneNumber: Joi.string().required().messages({
-    "any.required": "Phone Number required",
-  }),
+  phoneNumber: Joi.string().messages({}),
 
   address: Joi.string().messages({}),
 

--- a/Validation/User/registerValidator.js
+++ b/Validation/User/registerValidator.js
@@ -35,9 +35,7 @@ const RegisterSchema = Joi.object({
     "any.required": "Phone Number required",
   }),
 
-  address: Joi.string().required().messages({
-    "any.required": "Address required",
-  }),
+  address: Joi.string().messages({}),
 
   password: Joi.string()
     .required()

--- a/models/Otp.js
+++ b/models/Otp.js
@@ -8,8 +8,8 @@ const otpSchema = new Schema(
       id: { type: Schema.Types.ObjectId, required: true, refPath: "userType" },
       userType: {
         type: String,
-        required: true,
-        enum: ["student", "school", "volunteer", "admin", "partner"],
+
+        enum: ["student", "school", "volunteer", "admin", "partner", ""],
       },
     },
     otp: { type: String, required: true },

--- a/models/User.model.js
+++ b/models/User.model.js
@@ -49,7 +49,6 @@ const userSchema = new mongoose.Schema(
 
     address: {
       type: String,
-      required: true,
     },
   },
   {

--- a/models/User.model.js
+++ b/models/User.model.js
@@ -25,8 +25,8 @@ const userSchema = new mongoose.Schema(
 
     role: {
       type: String,
-      enum: ["student", "school", "volunteer", "admin", "partner"],
-      required: true,
+      enum: ["student", "school", "volunteer", "admin", "partner", ""],
+      default: "",
     },
 
     isVerified: {
@@ -36,7 +36,6 @@ const userSchema = new mongoose.Schema(
 
     phoneNumber: {
       type: String,
-      required: true,
     },
 
     grade: {


### PR DESCRIPTION
This PR removes the required constraint from the phonenumber, address, and role fields in the user schema to allow for more flexible user creation and updates. This is useful for workflows where this information is not immediately available or is optional.